### PR TITLE
added coalesce function for ssm params names so that ssm name can be configurable by anyone . by default it will take its default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SourceFuse AWS Reference Architecture (ARC) Terraform module for managing Worksp
 To see a Microsoft AD example, check out the [main.tf](https://github.com/sourcefuse/arc-terraform-workspace/blob/main/examples/Microsoft-AD/main.tf) file in the example folder.  
 
 ```hcl
-module "workspaces" {
+module "microsoft-ad-workspace" {
   source = "../../"
   region                             = var.region
   vpc_id                             = data.aws_vpc.vpc.id
@@ -35,7 +35,7 @@ module "workspaces" {
 To see a AD Connector example, check out the [main.tf](https://github.com/sourcefuse/arc-terraform-workspace/blob/main/examples/AD-Connector/main.tf) file in the example folder.
 
 ```hcl
-module "workspaces" {
+module "ad-connector-workspace" {
   source = "../../"
   region                             = var.region
   vpc_id                             = data.aws_vpc.vpc.id

--- a/README.md
+++ b/README.md
@@ -26,10 +26,38 @@ module "workspaces" {
   workspaces_self_service_access_arn = data.aws_iam_policy.workspaces_self_service_access.arn
   user_names                         = var.user_names
   workspace_properties               = var.workspace_properties
+  volume_encryption_key              = var.volume_encryption_key
   ip_rules                           = var.ip_rules // change it according to your requirement
   tags                               = module.tags.tags
 }
 ```
+
+To see a AD Connector example, check out the [main.tf](https://github.com/sourcefuse/arc-terraform-workspace/blob/main/examples/AD-Connector/main.tf) file in the example folder.
+
+```hcl
+module "workspaces" {
+  source = "../../"
+  region                             = var.region
+  vpc_id                             = data.aws_vpc.vpc.id
+  subnet_ids                         = data.aws_subnets.private.ids
+  directory_type                     = var.directory_type
+  directory_name                     = var.directory_name
+  directory_size                     = var.directory_size
+  self_service_permissions           = var.self_service_permissions
+  workspace_access_properties        = var.workspace_access_properties
+  workspace_creation_properties      = var.workspace_creation_properties
+  workspaces_service_access_arn      = data.aws_iam_policy.workspaces_service_access.arn
+  workspaces_self_service_access_arn = data.aws_iam_policy.workspaces_self_service_access.arn
+  user_names                         = var.user_names
+  customer_dns_ips                   = var.customer_dns_ips
+  customer_username                  = var.customer_username
+  workspace_properties               = var.workspace_properties
+  volume_encryption_key              = var.volume_encryption_key
+  ip_rules                           = var.ip_rules // change it according to your requirement
+  tags                               = module.tags.tags
+}
+```
+Both Examples look similar but the difference between them is ```customer_dns_ips``` and ```customer_username``` which is required for ADConnector but not required for AWS Managed Microsoft-AD
 ## IMPORTANT NOTE
 
 For user_names attribute which is shown in example. There are two approaches you can follow
@@ -113,6 +141,7 @@ No modules.
 | <a name="input_directory_size"></a> [directory\_size](#input\_directory\_size) | The size of the directory (Small or Large are accepted values). Large by default. | `string` | `"Small"` | no |
 | <a name="input_directory_type"></a> [directory\_type](#input\_directory\_type) | Type of the directory service (MicrosoftAD or ADConnector). | `string` | `"MicrosoftAD"` | no |
 | <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | List of egress rules | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = any<br>    cidr_blocks = optional(list(string), [])<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "from_port": 0,<br>    "protocol": -1,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | workspace iam-role-name | `string` | `"workspaces_DefaultRole"` | no |
 | <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | List of ingress rules | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = string<br>    cidr_blocks = optional(list(string), [])<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "from_port": 443,<br>    "protocol": "tcp",<br>    "to_port": 443<br>  }<br>]</pre> | no |
 | <a name="input_ip_group_description"></a> [ip\_group\_description](#input\_ip\_group\_description) | Description of the IP access control group | `string` | `"nat-gateway-ip-list control group"` | no |
 | <a name="input_ip_group_name"></a> [ip\_group\_name](#input\_ip\_group\_name) | Name of the IP access control group | `string` | `"nat-gateway-ip-list"` | no |
@@ -121,6 +150,8 @@ No modules.
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description of the security group | `string` | `"My security group description"` | no |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of the security group | `string` | `"workspace-SG"` | no |
 | <a name="input_self_service_permissions"></a> [self\_service\_permissions](#input\_self\_service\_permissions) | Self-service permissions configuration. | <pre>object({<br>    change_compute_type  = bool<br>    increase_volume_size = bool<br>    rebuild_workspace    = bool<br>    restart_workspace    = bool<br>    switch_running_mode  = bool<br>  })</pre> | <pre>{<br>  "change_compute_type": false,<br>  "increase_volume_size": false,<br>  "rebuild_workspace": false,<br>  "restart_workspace": true,<br>  "switch_running_mode": false<br>}</pre> | no |
+| <a name="input_ssm_ad_connector_parameter_name"></a> [ssm\_ad\_connector\_parameter\_name](#input\_ssm\_ad\_connector\_parameter\_name) | ssm parameter name for microsoft AD | `string` | `"/workspace/Connector/password"` | no |
+| <a name="input_ssm_parameter_name"></a> [ssm\_parameter\_name](#input\_ssm\_parameter\_name) | ssm parameter name for microsoft AD | `string` | `"/workspace/microsoft-ad/password"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | private subnet\_ids | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | tags to add to your resources | `map(string)` | n/a | yes |
 | <a name="input_user_names"></a> [user\_names](#input\_user\_names) | List of usernames to create workspaces for | `map(string)` | `{}` | no |

--- a/examples/AD-Connector/README.md
+++ b/examples/AD-Connector/README.md
@@ -18,8 +18,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_ad-connector-workspace"></a> [ad-connector-workspace](#module\_ad-connector-workspace) | ../../ | n/a |
 | <a name="module_tags"></a> [tags](#module\_tags) | git::https://github.com/sourcefuse/terraform-aws-refarch-tags.git | 1.2.1 |
-| <a name="module_workspaces"></a> [workspaces](#module\_workspaces) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/AD-Connector/main.tf
+++ b/examples/AD-Connector/main.tf
@@ -28,7 +28,7 @@ module "tags" {
   }
 }
 
-module "workspaces" {
+module "ad-connector-workspace" {
   source = "../../"
 
   region                             = var.region

--- a/examples/AD-Connector/outputs.tf
+++ b/examples/AD-Connector/outputs.tf
@@ -1,4 +1,4 @@
 output "workspace_directory_id" {
   description = "The ID of the AWS Workspaces directory."
-  value       = module.workspaces.workspace_directory_id
+  value       = module.ad-connector-workspace.workspace_directory_id
 }

--- a/examples/Microsoft-AD/README.md
+++ b/examples/Microsoft-AD/README.md
@@ -18,8 +18,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_microsoft-ad-workspace"></a> [microsoft-ad-workspace](#module\_microsoft-ad-workspace) | ../../ | n/a |
 | <a name="module_tags"></a> [tags](#module\_tags) | git::https://github.com/sourcefuse/terraform-aws-refarch-tags.git | 1.2.1 |
-| <a name="module_workspaces"></a> [workspaces](#module\_workspaces) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/Microsoft-AD/main.tf
+++ b/examples/Microsoft-AD/main.tf
@@ -28,7 +28,7 @@ module "tags" {
   }
 }
 
-module "workspaces" {
+module "microsoft-ad-workspace" {
   source = "../../"
 
   region                             = var.region

--- a/examples/Microsoft-AD/outputs.tf
+++ b/examples/Microsoft-AD/outputs.tf
@@ -1,4 +1,4 @@
 output "workspace_directory_id" {
   description = "The ID of the AWS Workspaces directory."
-  value       = module.workspaces.workspace_directory_id
+  value       = module.microsoft-ad-workspace.workspace_directory_id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  ssm_parameter_name              = var.directory_type == "MicrosoftAD" ? "/workspace/ad/password" : ""
-  ssm_ad_connector_parameter_name = var.directory_type == "ADConnector" ? "/workspace/adConnector/password" : ""
+  ssm_parameter_name              = var.directory_type == "MicrosoftAD" ? coalesce(var.ssm_parameter_name, "/workspace/ad/password") : ""
+  ssm_ad_connector_parameter_name = var.directory_type == "ADConnector" ? coalesce(var.ssm_ad_connector_parameter_name, "/workspace/adConnector/password") : ""
+
 }

--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,7 @@ resource "aws_directory_service_directory" "ADConnector" {
 ########### Iam role and Policy Attachment ##########################
 
 resource "aws_iam_role" "workspaces_default" {
-  name               = "workspaces_DefaultRole"
+  name               = var.iam_role_name
   assume_role_policy = data.aws_iam_policy_document.workspaces.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -229,3 +229,21 @@ variable "volume_encryption_key" {
   type        = string
   default     = ""
 }
+
+variable "iam_role_name" {
+  description = "workspace iam-role-name"
+  type        = string
+  default     = "workspaces_DefaultRole"
+}
+
+variable "ssm_parameter_name" {
+  description = "ssm parameter name for microsoft AD"
+  type        = string
+  default     = "/workspace/microsoft-ad/password"
+}
+
+variable "ssm_ad_connector_parameter_name" {
+  description = "ssm parameter name for microsoft AD"
+  type        = string
+  default     = "/workspace/Connector/password"
+}


### PR DESCRIPTION
I tested out and it worked perfectly

coalesce takes any number of arguments and returns the first one that isn't null or an empty string. But i have added a condition with this . if its null or an empty string then it will take the default value from locals and if there is a value in variables then coalesce will take the value from variables.


I know it can be done by simply creating variables but anything can be done with other way